### PR TITLE
starting point of abstraction of Msg-Bus

### DIFF
--- a/ts/src/msg-bus/msg-bus.test.ts
+++ b/ts/src/msg-bus/msg-bus.test.ts
@@ -1,0 +1,245 @@
+import { MockLogger } from "@adviser/runified/testutils";
+import { MsgBus, MsgBusConsumer } from "./msg-bus";
+import amqplib from "amqplib";
+import dotenv from "dotenv";
+import {
+  OpenSeaGetNFTV2Container$OpenSeaNFTV2,
+  OpenSeaGetNFTV2Container$OpenSeaNFTV2CoerceType,
+  OpenSeaGetNFTV2Container$OpenSeaNFTV2Factory,
+  OpenSeaGetNFTV2Container$OpenSeaNFTV2Object,
+} from "../types/generated/openseagetnftv2container$openseanftv2";
+import { SystemAbstractionImpl } from "@adviser/runified/utils";
+import { TimeMode } from "@adviser/runified/types";
+import { OpenSeaGetNFTV2ContainerFactory } from "../types/generated/openseagetnftv2container";
+
+dotenv.config();
+it("start-msg-bus", async () => {
+  const log = MockLogger();
+  const assertExchange = jest.fn();
+  const close = jest.fn();
+  const conn = {
+    createChannel: jest.fn().mockReturnValue({
+      close,
+      assertExchange,
+    }),
+  };
+  const mb = new MsgBus({
+    conn: conn as unknown as amqplib.Connection,
+    log: log.logger,
+  });
+  await mb.start();
+
+  await mb.stop();
+
+  expect(close).toBeCalledTimes(1);
+  expect(assertExchange).toBeCalledWith("msg-bus", "direct", { durable: false });
+});
+
+it("send-msg-bus", async () => {
+  const sys = new SystemAbstractionImpl({ TimeMode: TimeMode.CONST });
+  const log = MockLogger({ sys });
+  const conn = {};
+  const mb = new MsgBus({
+    conn: conn as unknown as amqplib.Connection,
+    log: log.logger,
+  });
+  const publish = jest.fn();
+  mb.channel = {
+    publish,
+  } as unknown as amqplib.Channel;
+  // await mb.start();
+
+  const myBuilder = OpenSeaGetNFTV2Container$OpenSeaNFTV2Factory.Builder();
+  myBuilder.Coerce({
+    identifier: "identifier",
+    collection: "collection",
+    contract: "contract",
+    token_standard: "token_standard",
+    name: "name",
+    description: "description",
+    created_at: sys.Time().Now().toISOString(),
+    updated_at: sys.Time().Now().toISOString(),
+  });
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  mb.send(OpenSeaGetNFTV2Container$OpenSeaNFTV2Factory.ToPayload(myBuilder.Get()));
+
+  expect(publish.mock.calls[0][0]).toEqual("msg-bus");
+  expect(publish.mock.calls[0][1]).toEqual("OpenSeaNFTV2");
+  expect(JSON.parse(publish.mock.calls[0][2].toString())).toEqual({
+    Data: {
+      collection: "collection",
+      contract: "contract",
+      created_at: sys.Time().Now().toISOString(),
+      description: "description",
+      identifier: "identifier",
+      name: "name",
+      token_standard: "token_standard",
+      updated_at: sys.Time().Now().toISOString(),
+    },
+    Type: "OpenSeaNFTV2",
+  });
+});
+
+it("consume-msg-bus", async () => {
+  const sys = new SystemAbstractionImpl({ TimeMode: TimeMode.CONST });
+  const log = MockLogger({ sys });
+  const conn = {};
+  const mb = new MsgBus({
+    conn: conn as unknown as amqplib.Connection,
+    log: log.logger,
+  });
+  const assertQueue = jest.fn();
+  const bindQueue = jest.fn();
+  const prefetch = jest.fn();
+  const consume = jest.fn();
+  const ack = jest.fn();
+  mb.channel = {
+    assertQueue,
+    bindQueue,
+    prefetch,
+    consume,
+    ack,
+  } as unknown as amqplib.Channel;
+  // await mb.start();
+
+  const handler = jest.fn();
+  const myC: MsgBusConsumer<
+    OpenSeaGetNFTV2Container$OpenSeaNFTV2,
+    OpenSeaGetNFTV2Container$OpenSeaNFTV2CoerceType,
+    OpenSeaGetNFTV2Container$OpenSeaNFTV2Object
+  > = {
+    name: "test",
+    prefetch: 9,
+    factory: OpenSeaGetNFTV2Container$OpenSeaNFTV2Factory,
+    handler,
+  };
+  await mb.consumer(myC);
+
+  expect(assertQueue.mock.calls[0][0]).toEqual("msg-bus-test");
+  expect(assertQueue.mock.calls[0][1]).toEqual({ durable: true });
+  expect(bindQueue.mock.calls[0][0]).toEqual("msg-bus-test");
+  expect(bindQueue.mock.calls[0][1]).toEqual("msg-bus");
+  expect(prefetch.mock.calls[0][0]).toEqual(9);
+  expect(consume.mock.calls[0][0]).toEqual("msg-bus-test");
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  mb.channel.publish = (qn: string, rt: string, msg: Buffer, opt) => {
+    expect(qn).toEqual("msg-bus");
+    expect(rt).toEqual("OpenSeaNFTV2");
+    consume.mock.calls[0][1]({
+      content: msg,
+      fields: {} as unknown as amqplib.MessageFields,
+      properties: {
+        headers: {
+          Type: "OpenSeaNFTV2",
+        },
+      } as unknown as amqplib.Options.Publish,
+    } as amqplib.ConsumeMessage);
+    return true;
+  };
+
+  const myBuilder = OpenSeaGetNFTV2Container$OpenSeaNFTV2Factory.Builder();
+  const ref = myBuilder.Coerce({
+    identifier: "identifier",
+    collection: "collection",
+    contract: "contract",
+    token_standard: "token_standard",
+    name: "name",
+    description: "description",
+    created_at: sys.Time().Now().toISOString(),
+    updated_at: sys.Time().Now().toISOString(),
+  });
+
+  await mb.send(OpenSeaGetNFTV2Container$OpenSeaNFTV2Factory.ToPayload(myBuilder.Get()));
+  await log.logger.Flush();
+
+  expect(log.logCollector.Logs()).toEqual([]);
+
+  expect(ack).toBeCalledTimes(1);
+
+  expect(handler.mock.calls[0][0]).toEqual(ref.unwrap());
+});
+
+it("consume-msg-bus-defect", async () => {
+  const sys = new SystemAbstractionImpl({ TimeMode: TimeMode.CONST });
+  const log = MockLogger({ sys });
+  const conn = {};
+  const mb = new MsgBus({
+    conn: conn as unknown as amqplib.Connection,
+    log: log.logger,
+  });
+  const assertQueue = jest.fn();
+  const bindQueue = jest.fn();
+  const prefetch = jest.fn();
+  const consume = jest.fn();
+  const ack = jest.fn();
+  mb.channel = {
+    assertQueue,
+    bindQueue,
+    prefetch,
+    consume,
+    ack,
+  } as unknown as amqplib.Channel;
+  // await mb.start();
+
+  const handler = jest.fn();
+  const myC: MsgBusConsumer<
+    OpenSeaGetNFTV2Container$OpenSeaNFTV2,
+    OpenSeaGetNFTV2Container$OpenSeaNFTV2CoerceType,
+    OpenSeaGetNFTV2Container$OpenSeaNFTV2Object
+  > = {
+    name: "test",
+    prefetch: 9,
+    factory: OpenSeaGetNFTV2Container$OpenSeaNFTV2Factory,
+    handler,
+  };
+  await mb.consumer(myC);
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  mb.channel.publish = (qn: string, rt: string, msg: Buffer, opt) => {
+    expect(qn).toEqual("msg-bus");
+    expect(rt).toEqual("OpenSeaGetNFTV2Container");
+    consume.mock.calls[0][1]({
+      content: msg,
+      fields: {} as unknown as amqplib.MessageFields,
+      properties: {
+        headers: {
+          Type: "OpenSeaNFTV2",
+        },
+      } as unknown as amqplib.Options.Publish,
+    } as amqplib.ConsumeMessage);
+    return true;
+  };
+
+  const myBuilder = OpenSeaGetNFTV2ContainerFactory.Builder();
+  myBuilder.Coerce({
+    nft: {
+      identifier: "identifier",
+      collection: "collection",
+      contract: "contract",
+      token_standard: "token_standard",
+      name: "name",
+      description: "description",
+      created_at: sys.Time().Now().toISOString(),
+      updated_at: sys.Time().Now().toISOString(),
+    },
+  });
+
+  await mb.send(OpenSeaGetNFTV2ContainerFactory.ToPayload(myBuilder.Get()));
+  await log.logger.Flush();
+
+  expect(ack).toBeCalledTimes(1);
+
+  expect(log.logCollector.Logs()).toEqual([
+    {
+      error:
+        "WuestePayload Type mismatch:[OpenSeaGetNFTV2Container$OpenSeaNFTV2,OpenSeaNFTV2,OpenSeaNFTV2] != OpenSeaGetNFTV2Container",
+      level: "error",
+      module: "msg-bus",
+      component: "consumer",
+      msg: "coerce",
+      name: "test",
+    },
+  ]);
+});

--- a/ts/src/msg-bus/msg-bus.ts
+++ b/ts/src/msg-bus/msg-bus.ts
@@ -1,0 +1,94 @@
+import { Logger } from "@adviser/runified/types";
+import amqplib from "amqplib";
+import { Result } from "wueste/result";
+import { Payload, WuestenFactory, WuestenReflectionObject } from "wueste/wueste";
+
+export interface MsgBusParams {
+  readonly conn: amqplib.Connection;
+  readonly log: Logger;
+  readonly exchangeName?: string;
+}
+
+export interface MsgBusConsumer<T, I, G> {
+  readonly name: string;
+  readonly prefetch?: number;
+  readonly factory: WuestenFactory<T, I, G>;
+  handler(msg: T): Promise<void>;
+}
+
+const txtEncoder = new TextEncoder();
+export class MsgBus {
+  readonly conn: amqplib.Connection;
+  readonly log: Logger;
+  readonly exchangeName: string;
+
+  channel?: amqplib.Channel;
+
+  constructor(params: MsgBusParams) {
+    this.conn = params.conn;
+    this.log = params.log.With().Module("msg-bus").Logger();
+    this.exchangeName = params.exchangeName || "msg-bus";
+  }
+
+  async start(): Promise<MsgBus> {
+    this.channel = await this.conn.createChannel();
+    await this.channel.assertExchange(this.exchangeName, "direct", { durable: false });
+    return this;
+  }
+
+  async stop() {
+    if (!this.channel) {
+      throw Error("channel not initialized");
+    }
+    await this.channel.close();
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  async send(rmsg: Result<Payload>) {
+    if (!this.channel) {
+      throw Error("channel not initialized");
+    }
+    if (rmsg.is_err()) {
+      throw rmsg.unwrap_err();
+    }
+    const jsonStr = JSON.stringify(rmsg.unwrap());
+    this.log.Debug().Str("component", "send").Str("routingKey", rmsg.unwrap().Type).Any("payload", rmsg.unwrap().Data).Msg("send");
+    this.channel.publish(this.exchangeName, rmsg.unwrap().Type, Buffer.from(txtEncoder.encode(jsonStr)));
+  }
+
+  async consumer<T, I, G>(c: MsgBusConsumer<T, I, G>) {
+    if (!this.channel) {
+      throw Error("channel not initialized");
+    }
+    const log = this.log.With().Str("component", "consumer").Str("name", c.name).Logger();
+    const qname = `${this.exchangeName}-${c.name}`;
+    await this.channel.assertQueue(qname, { durable: true });
+    const rtk = (c.factory.Schema() as WuestenReflectionObject).id!;
+    await this.channel.bindQueue(qname, this.exchangeName, rtk);
+
+    log.Debug().Str("queueName", qname).Str("exchangeName", this.exchangeName).Str("routingKey", rtk).Msg("consumer start");
+    this.channel.prefetch(c.prefetch || 1);
+    this.channel.consume(qname, (msg) => {
+      if (!msg) {
+        return;
+      }
+      try {
+        const r = c.factory.FromPayload(JSON.parse(msg.content.toString()));
+        if (r.is_err()) {
+          log.Error().Err(r.unwrap_err()).Msg("coerce");
+          this.channel!.ack(msg);
+          return;
+        }
+        log.Debug().Any("payload", r.unwrap()).Msg("pass to handler");
+        c.handler(r.unwrap());
+        this.channel!.ack(msg);
+      } catch (e) {
+        this.channel!.ack(msg);
+        log
+          .Error()
+          .Err(e as Error)
+          .Msg("msg-bus");
+      }
+    });
+  }
+}

--- a/ts/src/msg-bus/retry-handler.test.ts
+++ b/ts/src/msg-bus/retry-handler.test.ts
@@ -1,0 +1,1009 @@
+import amqplib from "amqplib";
+import {
+  RetryHandler,
+  RetryHandlerParams,
+  RetryHandlerResult,
+  RetryManager,
+  RetryStep,
+  keyAsString,
+  randomDelayStrategy,
+} from "./retry-handler";
+import { MockLogger } from "@adviser/runified/testutils";
+import { createMockPrismaContext } from "../prisma/mockPrisma";
+import { Prisma } from "../prisma/client";
+import { SystemAbstractionImpl } from "@adviser/runified/utils";
+import { TimeMode, IDMode, RandomMode } from "@adviser/runified/types";
+import { PrismaClient } from "@prisma/client";
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+function createRetryStateTransaction(prisma: PrismaClient, sys: SystemAbstractionImpl) {
+  prisma.retryStates.create = jest.fn().mockImplementation((msg) => {
+    return Promise.resolve(msg.data);
+  });
+}
+it("random delay stategry", () => {
+  const sys = new SystemAbstractionImpl({ RandomMode: RandomMode.STEP });
+  expect(randomDelayStrategy(0, 2, sys)).toBe(0.5001);
+  expect(randomDelayStrategy(8, 2, sys)).toBe(128.0512);
+  expect(randomDelayStrategy(8, 2, sys)).toBe(128.0768);
+});
+
+it("send defect json undefined", async () => {
+  const log = MockLogger();
+  const rm = new RetryManager({
+    log: log.logger,
+  } as RetryHandlerParams);
+  const ack = jest.fn();
+  const ch = { ack } as unknown as amqplib.Channel;
+  await rm.msgHandler(log.logger, ch, { content: Buffer.from("@}{") } as amqplib.ConsumeMessage);
+  expect(ack).toBeCalledTimes(1);
+  await log.logger.Flush();
+  const logs = log.logCollector.Logs();
+  expect(logs[0].error).toContain("Unexpected token");
+  logs[0].error = "Unexpected token @ in JSON at position 0";
+  expect(logs).toEqual([
+    {
+      error: "Unexpected token @ in JSON at position 0",
+      level: "error",
+      msg: "channel unknown error",
+    },
+  ]);
+});
+it("send defect json null", async () => {
+  const log = MockLogger();
+  const rm = new RetryManager({
+    log: log.logger,
+  } as RetryHandlerParams);
+  const ack = jest.fn();
+  const ch = { ack } as unknown as amqplib.Channel;
+  await rm.msgHandler(log.logger, ch, { content: Buffer.from("null") } as amqplib.ConsumeMessage);
+  expect(ack).toBeCalledTimes(1);
+  expect(log.logCollector.Logs()).toEqual([
+    {
+      headers: {},
+      payload: null,
+      module: "RetryManager",
+      level: "error",
+      msg: "payload not exist",
+    },
+  ]);
+});
+
+function expectFindUnique<T = string>(sys: SystemAbstractionImpl, prisma: PrismaClient, key?: T) {
+  if (!key) {
+    key = "max" as T;
+  }
+  const keyStr = keyAsString(key);
+  expect(prisma.retryStates.findUnique).toBeCalledTimes(2);
+  expect(prisma.retryStates.findUnique.mock.calls[0][0]).toEqual({
+    where: {
+      handler_key: {
+        handler: "wurst",
+        key: keyStr,
+      },
+    },
+  });
+  expect(prisma.retryStates.findUnique.mock.calls[1][0]).toEqual({
+    where: {
+      handler_key: {
+        handler: "wurst",
+        key: keyStr,
+      },
+      txn: "STEPId-0",
+    },
+  });
+  expect(prisma.retryStates.create).toBeCalledWith({
+    data: {
+      created_at: sys.Time().Now(),
+      handler: "wurst",
+      key: keyStr,
+      real_key: key,
+      state: "new",
+      steps: [],
+      txn: "STEPId-0",
+      updated_at: sys.Time().Now(),
+    },
+  });
+}
+it("stop on retryCount", async () => {
+  const log = MockLogger();
+  const sys = new SystemAbstractionImpl({ TimeMode: TimeMode.CONST, IdMode: IDMode.STEP });
+  const pctx = createMockPrismaContext();
+  createRetryStateTransaction(pctx.prisma, sys);
+  const rm = new RetryManager({
+    log: log.logger,
+    prisma: pctx.prisma,
+    sys: sys,
+  } as unknown as RetryHandlerParams);
+  const handler = {
+    name: "wurst",
+    handle: jest.fn(),
+    config: {},
+  };
+  rm.registerHandler(handler);
+  const ack = jest.fn();
+  const ch = { ack } as unknown as amqplib.Channel;
+  await rm.msgHandler(log.logger, ch, {
+    content: Buffer.from(JSON.stringify({ handler: "wurst", key: "max" })),
+    properties: {
+      headers: {
+        "x-retry-count": 10,
+      },
+    } as unknown as amqplib.MessageProperties,
+  } as amqplib.ConsumeMessage);
+  expect(ack).toBeCalledTimes(1);
+  expect(log.logCollector.Logs()).toEqual([
+    {
+      handler: "wurst",
+      headers: {
+        "x-retry-count": 10,
+      },
+      level: "error",
+      module: "RetryManager",
+      msg: "max retry reached",
+      payload: {
+        handler: "wurst",
+        key: "max",
+        txn: "STEPId-0",
+      },
+      retryCount: 10,
+    },
+  ]);
+
+  expectFindUnique(sys, pctx.prisma);
+  expect(pctx.prisma.retryStates.update).toBeCalledWith({
+    where: {
+      handler_key: {
+        handler: "wurst",
+        key: "max",
+      },
+      txn: "STEPId-0",
+    },
+    data: {
+      state: "error",
+      steps: [
+        {
+          error: { error: "max retry reached" },
+          stepAt: sys.Time().Now(),
+          value: {
+            payload: {
+              handler: "wurst",
+              key: "max",
+              txn: "STEPId-0",
+            },
+            headers: {
+              "x-retry-count": 10,
+            },
+          },
+        } as RetryStep,
+      ],
+      updated_at: sys.Time().Now(),
+    },
+  });
+});
+
+it("no handler", async () => {
+  const log = MockLogger();
+  const sys = new SystemAbstractionImpl({ TimeMode: TimeMode.CONST, IdMode: IDMode.STEP });
+  const pctx = createMockPrismaContext();
+  createRetryStateTransaction(pctx.prisma, sys);
+  const rm = new RetryManager({
+    log: log.logger,
+    prisma: pctx.prisma,
+    sys: sys,
+  } as unknown as RetryHandlerParams);
+  const ack = jest.fn();
+  const ch = { ack } as unknown as amqplib.Channel;
+  await rm.msgHandler(log.logger, ch, {
+    content: Buffer.from(JSON.stringify({ handler: "wurst", key: "max" })),
+    properties: {} as unknown as amqplib.MessageProperties,
+  } as amqplib.ConsumeMessage);
+  expect(ack).toBeCalledTimes(1);
+  expect(log.logCollector.Logs()).toEqual([
+    {
+      handler: "wurst",
+      level: "error",
+      module: "RetryManager",
+      msg: "handler not found",
+      payload: {
+        handler: "wurst",
+        key: "max",
+      },
+    },
+  ]);
+  expect(pctx.prisma.retryStates.findUnique).toBeCalledTimes(0);
+  expect(pctx.prisma.retryStates.update).toBeCalledTimes(0);
+  expect(pctx.prisma.retryStates.create).toBeCalledTimes(0);
+});
+it("handler ok invalid result", async () => {
+  const log = MockLogger();
+  const sys = new SystemAbstractionImpl({ TimeMode: TimeMode.CONST, IdMode: IDMode.STEP });
+  const pctx = createMockPrismaContext();
+  createRetryStateTransaction(pctx.prisma, sys);
+  const rm = new RetryManager({
+    log: log.logger,
+    prisma: pctx.prisma,
+    sys: sys,
+  } as unknown as RetryHandlerParams);
+  const ack = jest.fn();
+  const ch = { ack } as unknown as amqplib.Channel;
+  const handler = {
+    name: "wurst",
+    handle: jest.fn(),
+    config: {},
+  };
+  rm.registerHandler(handler);
+  const key = { handler: "wurst", key: "max" };
+  const msg = {
+    content: Buffer.from(JSON.stringify(key)),
+    properties: {} as unknown as amqplib.MessageProperties,
+  } as amqplib.ConsumeMessage;
+  await rm.msgHandler(log.logger, ch, msg);
+  expect(ack).toBeCalledTimes(1);
+  expect(handler.handle).toBeCalledTimes(1);
+  expect(handler.handle.mock.calls[0][0]).toEqual(msg);
+  expect(handler.handle.mock.calls[0][1]).toEqual({ ...key, txn: "STEPId-0" });
+  expect(log.logCollector.Logs()).toEqual([
+    {
+      handler: "wurst",
+      level: "error",
+      msg: "handler result invalid",
+      module: "RetryManager",
+      payload: {
+        handler: "wurst",
+        key: "max",
+        txn: "STEPId-0",
+      },
+    },
+  ]);
+  expectFindUnique(sys, pctx.prisma);
+  expect(pctx.prisma.retryStates.update).toBeCalledWith({
+    where: {
+      handler_key: {
+        handler: "wurst",
+        key: "max",
+      },
+      txn: "STEPId-0",
+    },
+    data: {
+      state: "error",
+      steps: [
+        {
+          error: { error: "invalid result" },
+          stepAt: sys.Time().Now(),
+          value: {
+            payload: {
+              handler: "wurst",
+              key: "max",
+              txn: "STEPId-0",
+            },
+            headers: undefined,
+          },
+        } as RetryStep,
+      ],
+      updated_at: sys.Time().Now(),
+    },
+  });
+});
+
+interface MyKey {
+  K1: string;
+  K2: number;
+}
+
+it("handler ok with result", async () => {
+  const log = MockLogger();
+  log.logger.SetDebug("RetryManager");
+  const sys = new SystemAbstractionImpl({ TimeMode: TimeMode.CONST, IdMode: IDMode.STEP });
+  const pctx = createMockPrismaContext();
+  createRetryStateTransaction(pctx.prisma, sys);
+  const rm = new RetryManager({
+    log: log.logger,
+    prisma: pctx.prisma,
+    sys: sys,
+  } as unknown as RetryHandlerParams);
+  const ack = jest.fn();
+  const ch = { ack } as unknown as amqplib.Channel;
+  const handler: RetryHandler<MyKey> = {
+    name: "wurst",
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    handle: (msg, key) => {
+      return Promise.resolve({
+        ...key,
+        retry: false,
+      });
+    },
+    config: {},
+  };
+  rm.registerHandler(handler);
+  const key = { handler: "wurst", key: { K1: "k1", K2: true, K3: "What" } };
+  const msg = {
+    content: Buffer.from(JSON.stringify(key)),
+    properties: {} as unknown as amqplib.MessageProperties,
+  } as amqplib.ConsumeMessage;
+  await rm.msgHandler(log.logger, ch, msg);
+  expect(ack).toBeCalledTimes(1);
+  expect(JSON.parse(ack.mock.calls[0][0].content.toString())).toEqual({
+    handler: "wurst",
+    key: { K1: "k1", K2: true, K3: "What" },
+  });
+  expect(log.logCollector.Logs()).toEqual([
+    {
+      handler: "wurst",
+      level: "debug",
+      module: "RetryManager",
+      msg: "handler done",
+      payload: {
+        handler: "wurst",
+        key: { K1: "k1", K2: true, K3: "What" },
+        txn: "STEPId-0",
+      },
+      res: {
+        handler: "wurst",
+        key: { K1: "k1", K2: true, K3: "What" },
+        retry: false,
+        txn: "STEPId-0",
+      },
+      stats: {
+        "wurst#": {
+          cnt: 1,
+          unit: "ns",
+          val: 0,
+        },
+      },
+    },
+  ]);
+  expectFindUnique(sys, pctx.prisma, { K1: "k1", K2: true, K3: "What" });
+  expect(pctx.prisma.retryStates.update).toBeCalledWith({
+    where: {
+      handler_key: {
+        handler: "wurst",
+        key: "k1|true|What",
+      },
+      txn: "STEPId-0",
+    },
+    data: {
+      state: "done",
+      steps: [
+        {
+          headers: undefined,
+          stats: {
+            "wurst#": {
+              cnt: 1,
+              unit: "ns",
+              val: 0,
+            },
+          },
+          stepAt: sys.Time().Now(),
+          value: {
+            ctx: undefined,
+            headers: undefined,
+            payload: {
+              handler: "wurst",
+              key: { K1: "k1", K2: true, K3: "What" },
+              next: undefined,
+              txn: "STEPId-0",
+            },
+          },
+        },
+      ],
+      updated_at: sys.Time().Now(),
+    },
+  });
+});
+
+it("handler ok with next", async () => {
+  const log = MockLogger();
+  log.logger.SetDebug("RetryManager");
+  const sys = new SystemAbstractionImpl({ TimeMode: TimeMode.CONST, IdMode: IDMode.STEP });
+  const pctx = createMockPrismaContext();
+  createRetryStateTransaction(pctx.prisma, sys);
+  const rm = new RetryManager({
+    log: log.logger,
+    prisma: pctx.prisma,
+    sys: sys,
+  } as unknown as RetryHandlerParams);
+  const ack = jest.fn();
+  const publish = jest.fn();
+  const ch = { ack, publish } as unknown as amqplib.Channel;
+  const handler: RetryHandler<MyKey> = {
+    name: "wurst",
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    handle: (msg, key) => {
+      return Promise.resolve({
+        ...key,
+        retry: false,
+        next: { bax: 4711 },
+      } as RetryHandlerResult);
+    },
+    config: {},
+  };
+  rm.registerHandler(handler);
+  const key = { handler: "wurst", key: "max" };
+  const msg = {
+    content: Buffer.from(JSON.stringify(key)),
+    properties: {} as unknown as amqplib.MessageProperties,
+  } as amqplib.ConsumeMessage;
+  await rm.msgHandler(log.logger, ch, msg);
+  expect(ack).toBeCalledTimes(1);
+  expect(JSON.parse(ack.mock.calls[0][0].content.toString())).toEqual({ handler: "wurst", key: "max" });
+  expect(publish).toBeCalledTimes(1);
+  expect(JSON.parse(publish.mock.calls[0][2].toString())).toEqual({
+    handler: "wurst",
+    key: "max",
+    next: { bax: 4711 },
+    txn: "STEPId-0",
+  });
+
+  expect(log.logCollector.Logs()).toEqual([
+    {
+      handler: "wurst",
+      level: "debug",
+      module: "RetryManager",
+      msg: "handler done",
+      payload: {
+        handler: "wurst",
+        key: "max",
+        next: { bax: 4711 },
+        txn: "STEPId-0",
+      },
+      res: {
+        handler: "wurst",
+        key: "max",
+        retry: false,
+        next: { bax: 4711 },
+        txn: "STEPId-0",
+      },
+      stats: {
+        "wurst#": {
+          cnt: 1,
+          unit: "ns",
+          val: 0,
+        },
+      },
+    },
+  ]);
+  expectFindUnique(sys, pctx.prisma);
+  expect(pctx.prisma.retryStates.update).toBeCalledWith({
+    where: {
+      handler_key: {
+        handler: "wurst",
+        key: "max",
+      },
+      txn: "STEPId-0",
+    },
+    data: {
+      state: "next",
+      steps: [
+        {
+          stats: {
+            "wurst#": {
+              cnt: 1,
+              unit: "ns",
+              val: 0,
+            },
+          },
+          stepAt: sys.Time().Now(),
+          value: {
+            ctx: undefined,
+            payload: {
+              handler: "wurst",
+              key: "max",
+              next: { bax: 4711 },
+              txn: "STEPId-0",
+            },
+            headers: undefined,
+          },
+        },
+      ],
+      updated_at: sys.Time().Now(),
+    },
+  });
+});
+
+it("handler retry", async () => {
+  const log = MockLogger();
+  log.logger.SetDebug("RetryManager");
+  const sys = new SystemAbstractionImpl({ TimeMode: TimeMode.CONST, IdMode: IDMode.STEP });
+  const pctx = createMockPrismaContext();
+  createRetryStateTransaction(pctx.prisma, sys);
+  const rm = new RetryManager({
+    log: log.logger,
+    prisma: pctx.prisma,
+    sys: sys,
+  } as unknown as RetryHandlerParams);
+  const ack = jest.fn();
+  const publish = jest.fn();
+  const ch = { ack, publish } as unknown as amqplib.Channel;
+  const handler: RetryHandler<MyKey> = {
+    name: "wurst",
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    handle: (msg, key) => {
+      return Promise.resolve({
+        ...key,
+        retry: true,
+        next: { bax: 4711 },
+      } as RetryHandlerResult);
+    },
+    config: {},
+  };
+  rm.registerHandler(handler);
+  const key = { handler: "wurst", key: "max" };
+  const msg = {
+    content: Buffer.from(JSON.stringify(key)),
+    properties: {
+      headers: {
+        test: "test",
+        "x-retry-count": 2,
+      },
+      userId: "userId",
+    } as unknown as amqplib.MessageProperties,
+  } as amqplib.ConsumeMessage;
+  await rm.msgHandler(log.logger, ch, msg);
+  expect(ack).toBeCalledTimes(1);
+  expect(JSON.parse(ack.mock.calls[0][0].content.toString())).toEqual({ handler: "wurst", key: "max" });
+  expect(publish).toBeCalledTimes(1);
+  expect(JSON.parse(publish.mock.calls[0][2].toString())).toEqual({
+    handler: "wurst",
+    key: "max",
+    next: { bax: 4711 },
+    txn: "STEPId-0",
+  });
+  expect(publish.mock.calls[0][3]).toEqual({
+    headers: {
+      test: "test",
+      "x-delay": 8000,
+      "x-retry-count": 3,
+    },
+    userId: "userId",
+  });
+
+  expect(log.logCollector.Logs()).toEqual([
+    {
+      handler: "wurst",
+      level: "debug",
+      module: "RetryManager",
+      msg: "handler done",
+      headers: {
+        test: "test",
+        "x-delay": 8000,
+        "x-retry-count": 3,
+      },
+      payload: {
+        handler: "wurst",
+        key: "max",
+        next: { bax: 4711 },
+        txn: "STEPId-0",
+      },
+      res: {
+        handler: "wurst",
+        key: "max",
+        retry: true,
+        next: { bax: 4711 },
+        txn: "STEPId-0",
+      },
+      stats: {
+        "wurst#": {
+          cnt: 1,
+          unit: "ns",
+          val: 0,
+        },
+      },
+    },
+  ]);
+  expectFindUnique(sys, pctx.prisma);
+  expect(pctx.prisma.retryStates.update).toBeCalledWith({
+    where: {
+      handler_key: {
+        handler: "wurst",
+        key: "max",
+      },
+      txn: "STEPId-0",
+    },
+    data: {
+      state: "retrying",
+      steps: [
+        {
+          stats: {
+            "wurst#": {
+              cnt: 1,
+              unit: "ns",
+              val: 0,
+            },
+          },
+          stepAt: sys.Time().Now(),
+          value: {
+            ctx: undefined,
+            headers: {
+              test: "test",
+              "x-delay": 8000,
+              "x-retry-count": 3,
+            },
+            payload: {
+              handler: "wurst",
+              key: "max",
+              next: { bax: 4711 },
+              txn: "STEPId-0",
+            },
+          },
+        } as RetryStep,
+      ],
+      updated_at: sys.Time().Now(),
+    },
+  });
+});
+
+it("handler exception", async () => {
+  const log = MockLogger();
+  log.logger.Module("xx").SetDebug("xx");
+  const sys = new SystemAbstractionImpl({ TimeMode: TimeMode.CONST, IdMode: IDMode.STEP });
+  const pctx = createMockPrismaContext();
+  createRetryStateTransaction(pctx.prisma, sys);
+  const rm = new RetryManager({
+    log: log.logger,
+    prisma: pctx.prisma,
+    sys: sys,
+  } as unknown as RetryHandlerParams);
+  const ack = jest.fn();
+  const publish = jest.fn();
+  const ch = { ack, publish } as unknown as amqplib.Channel;
+  const handler: RetryHandler<MyKey> = {
+    name: "wurst",
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    handle: (msg, key) => {
+      throw new Error("wurst");
+    },
+    config: {},
+  };
+  rm.registerHandler(handler);
+  const key = { handler: "wurst", key: "max" };
+  const msg = {
+    content: Buffer.from(JSON.stringify(key)),
+  } as amqplib.ConsumeMessage;
+  await rm.msgHandler(log.logger, ch, msg);
+  expect(ack).toBeCalledTimes(1);
+  expect(JSON.parse(ack.mock.calls[0][0].content.toString())).toEqual({ handler: "wurst", key: "max" });
+
+  expect(log.logCollector.Logs()).toEqual([
+    {
+      error: "wurst",
+      handler: "wurst",
+      level: "error",
+      module: "RetryManager",
+      headers: {},
+      msg: "msg unknown error",
+      payload: {
+        handler: "wurst",
+        key: "max",
+        txn: "STEPId-0",
+      },
+    },
+  ]);
+  expectFindUnique(sys, pctx.prisma);
+  expect(pctx.prisma.retryStates.update).toBeCalledWith({
+    where: {
+      handler_key: {
+        handler: "wurst",
+        key: "max",
+      },
+      txn: "STEPId-0",
+    },
+    data: {
+      state: "error",
+      steps: [
+        {
+          stepAt: sys.Time().Now(),
+          error: { error: "wurst" },
+          value: {
+            headers: {},
+            payload: {
+              handler: "wurst",
+              key: "max",
+              txn: "STEPId-0",
+            },
+          },
+        } as RetryStep,
+      ],
+      updated_at: sys.Time().Now(),
+    },
+  });
+});
+
+it("handler sents error", async () => {
+  const log = MockLogger();
+  const sys = new SystemAbstractionImpl({ TimeMode: TimeMode.CONST, IdMode: IDMode.STEP });
+  const pctx = createMockPrismaContext();
+  createRetryStateTransaction(pctx.prisma, sys);
+  const rm = new RetryManager({
+    log: log.logger,
+    prisma: pctx.prisma,
+    sys: sys,
+  } as unknown as RetryHandlerParams);
+  const ack = jest.fn();
+  const publish = jest.fn();
+  const ch = { ack, publish } as unknown as amqplib.Channel;
+  const handler: RetryHandler<MyKey> = {
+    name: "wurst",
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    handle: (msg, key) => {
+      return Promise.resolve({
+        error: Error("meno ist doof"),
+        ctx: {
+          what: 48,
+          wunderful: "World",
+        },
+      } as RetryHandlerResult);
+    },
+    config: {},
+  };
+  rm.registerHandler(handler);
+  const key = { handler: "wurst", key: { K1: "k1", K2: 4711 } };
+  const msg = {
+    content: Buffer.from(JSON.stringify(key)),
+  } as amqplib.ConsumeMessage;
+  await rm.msgHandler(log.logger, ch, msg);
+  expect(ack).toBeCalledTimes(1);
+  expect(JSON.parse(ack.mock.calls[0][0].content.toString())).toEqual({ handler: "wurst", key: { K1: "k1", K2: 4711 } });
+
+  expect(log.logCollector.Logs()).toEqual([
+    {
+      handler: "wurst",
+      level: "error",
+      module: "RetryManager",
+      headers: {},
+
+      ctx: {
+        what: 48,
+        wunderful: "World",
+      },
+      error: "meno ist doof",
+
+      msg: "handler reports error",
+      payload: {
+        handler: "wurst",
+        key: { K1: "k1", K2: 4711 },
+        txn: "STEPId-0",
+      },
+    },
+  ]);
+  expectFindUnique(sys, pctx.prisma, { K1: "k1", K2: 4711 });
+
+  expect(pctx.prisma.retryStates.update).toBeCalledWith({
+    where: {
+      handler_key: {
+        handler: "wurst",
+        key: "k1|4711",
+      },
+      txn: "STEPId-0",
+    },
+    data: {
+      state: "error",
+      steps: [
+        {
+          stepAt: sys.Time().Now(),
+          error: {
+            error: "meno ist doof",
+          },
+          value: {
+            headers: {},
+            payload: {
+              handler: "wurst",
+              key: { K1: "k1", K2: 4711 },
+              txn: "STEPId-0",
+            },
+            ctx: {
+              what: 48,
+              wunderful: "World",
+            },
+          },
+        } as RetryStep,
+      ],
+      updated_at: sys.Time().Now(),
+    },
+  });
+});
+
+it("appends to updateState", async () => {
+  const log = MockLogger();
+  log.logger.Module("xx").SetDebug("xx");
+  const sys = new SystemAbstractionImpl({ TimeMode: TimeMode.CONST });
+  const pctx = createMockPrismaContext();
+  pctx.prisma.retryStates.findUnique.mockResolvedValueOnce({
+    created_at: sys.Time().Now(),
+    handler: "test",
+    key: "test",
+    state: "test",
+    real_key: { K1: "K1", K3: 461 },
+    txn: "txnId",
+    steps: [
+      {
+        stepAt: sys.Time().Now(),
+        value: {
+          payload: { handler: "test", key: "test" },
+          headers: { "x-retry-count": 1 },
+        },
+      },
+    ] as unknown as Prisma.JsonValue,
+    updated_at: sys.Time().Now(),
+  });
+  const rm = new RetryManager({
+    log: log.logger,
+    prisma: pctx.prisma,
+    sys: sys,
+  } as unknown as RetryHandlerParams);
+  await rm.updateState({
+    state: "test",
+    handler: "test",
+    key: "test",
+    txn: "txnId",
+    steps: [
+      {
+        stepAt: sys.Time().Now(),
+        value: {
+          payload: { handler: "test", key: "move", txn: "txnId" },
+          headers: { "x-retry-count": 2 },
+        },
+      },
+    ],
+    updated_at: sys.Time().Now(),
+    created_at: sys.Time().Now(),
+  });
+  expect(pctx.prisma.retryStates.findUnique).toBeCalledWith({
+    where: {
+      handler_key: {
+        handler: "test",
+        key: "test",
+      },
+      txn: "txnId",
+    },
+  });
+  expect(pctx.prisma.retryStates.update).toBeCalledWith({
+    data: {
+      state: "test",
+      steps: [
+        {
+          stepAt: sys.Time().Now(),
+          value: {
+            headers: {
+              "x-retry-count": 1,
+            },
+            payload: {
+              handler: "test",
+              key: "test",
+            },
+          },
+        },
+        {
+          stepAt: sys.Time().Now(),
+          value: {
+            headers: {
+              "x-retry-count": 2,
+            },
+            payload: {
+              handler: "test",
+              key: "move",
+              txn: "txnId",
+            },
+          },
+        },
+      ],
+      updated_at: sys.Time().Now(),
+    },
+    where: {
+      handler_key: {
+        handler: "test",
+        key: "test",
+      },
+      txn: "txnId",
+    },
+  });
+});
+
+type tmpStates = Prisma.PrismaPromise<
+  {
+    state: string;
+    handler: string;
+    key: string;
+    txn: string;
+    real_key: Prisma.JsonValue;
+    steps: Prisma.JsonValue;
+    updated_at: Date;
+    created_at: Date;
+  }[]
+>;
+
+it("reclaimTest empty", async () => {
+  const log = MockLogger();
+  const sys = new SystemAbstractionImpl({ TimeMode: TimeMode.CONST });
+  const pctx = createMockPrismaContext();
+
+  const ack = jest.fn();
+  const publish = jest.fn();
+  const ch = { ack, publish } as unknown as amqplib.Channel;
+
+  const rm = new RetryManager({
+    log: log.logger,
+    prisma: pctx.prisma,
+    sys: sys,
+  } as unknown as RetryHandlerParams);
+
+  const handler: RetryHandler<MyKey> = {
+    name: "wurst",
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    handle: async (msg, key) => {
+      return Promise.resolve({});
+    },
+    config: {},
+  };
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars, @typescript-eslint/no-explicit-any
+  pctx.prisma.retryStates.findMany.mockImplementationOnce(() => [] as unknown as tmpStates);
+
+  await rm.reclaimByHandler(log.logger, pctx.prisma, handler, ch);
+
+  expect(publish).toBeCalledTimes(0);
+});
+
+it("reclaimTest elements", async () => {
+  const log = MockLogger();
+  const sys = new SystemAbstractionImpl({ TimeMode: TimeMode.CONST });
+  const pctx = createMockPrismaContext();
+
+  const ack = jest.fn();
+  const publish = jest.fn();
+  const ch = { ack, publish } as unknown as amqplib.Channel;
+
+  const rm = new RetryManager({
+    log: log.logger,
+    prisma: pctx.prisma,
+    sys: sys,
+  } as unknown as RetryHandlerParams);
+
+  const handler: RetryHandler<MyKey> = {
+    name: "wurst",
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    handle: async (msg, key) => {
+      return Promise.resolve({});
+    },
+    config: {},
+  };
+
+  const val = [
+    {
+      state: "murks",
+      handler: "wurst",
+      key: "hut",
+      txn: "hut",
+      real_key: "hut",
+      steps: [],
+      updated_at: sys.Time().Now(),
+      created_at: sys.Time().Now(),
+    },
+    {
+      state: "mirks",
+      handler: "wurst",
+      key: "hut|45",
+      txn: "moks",
+      real_key: { a: "hut", c: 45 },
+      steps: [],
+      updated_at: sys.Time().Now(),
+      created_at: sys.Time().Now(),
+    },
+  ];
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars, @typescript-eslint/no-explicit-any
+  pctx.prisma.retryStates.findMany.mockImplementationOnce(() => val as unknown as tmpStates);
+
+  await rm.reclaimByHandler(log.logger, pctx.prisma, handler, ch);
+
+  expect(publish).toBeCalledTimes(2);
+  expect(JSON.parse(publish.mock.calls[0][2].toString())).toEqual({
+    handler: val[0].handler,
+    key: val[0].real_key,
+    txn: val[0].txn,
+  });
+  expect(JSON.parse(publish.mock.calls[1][2].toString())).toEqual({
+    handler: val[1].handler,
+    key: val[1].real_key,
+    txn: val[1].txn,
+  });
+});

--- a/ts/src/msg-bus/retry-handler.ts
+++ b/ts/src/msg-bus/retry-handler.ts
@@ -1,0 +1,531 @@
+import { Message, Connection, Channel, ConsumeMessage } from "amqplib";
+import { PrismaClient, Prisma } from "../prisma/client";
+import { Logger, SysAbstraction } from "@adviser/runified/types";
+import { Stats, SystemAbstractionImpl } from "@adviser/runified/utils";
+import { sanitizeJson } from "./sanitize-elastic-search";
+import { walk } from "wueste/helper";
+
+export interface RetryHandlerResult {
+  readonly retry?: boolean;
+  readonly next?: unknown;
+  readonly error?: Error;
+  readonly ctx?: unknown;
+}
+
+export interface RetryHandlerConfig {
+  readonly refreshInterval: number;
+  readonly errorRetryInterval: number;
+  readonly restartInterval: number;
+  readonly retryCount: number;
+  readonly delayStrategy: (delay: number, prevDelay: number, sys: SysAbstraction) => number;
+  readonly initialRetryDelay: number;
+}
+
+export interface RetryHandler<T> {
+  readonly name: string;
+  handle(msg: Message, payload: RetryMsg<T>, stat: Stats): Promise<RetryHandlerResult>;
+  readonly config: Partial<RetryHandlerConfig>;
+}
+
+export interface RetryMsg<T> {
+  readonly key: T;
+  readonly handler: string;
+  readonly next?: unknown;
+  readonly txn: string;
+}
+export interface RetryStep {
+  readonly stepAt: Date;
+  readonly value: {
+    readonly payload: RetryMsg<unknown>;
+    readonly headers?: Record<string, unknown>;
+    readonly ctx?: unknown;
+  };
+  readonly error?: {
+    readonly error: string;
+  };
+  readonly stats?: unknown;
+}
+
+export interface RetryState {
+  readonly state: string; // "fetching" | "retrying" | "done" | "error"
+  readonly handler: string;
+  readonly key: string;
+  readonly txn: string;
+  readonly steps: RetryStep[];
+  readonly updated_at: Date;
+  readonly created_at: Date;
+}
+
+export type RetryStatePrisma = RetryState & { readonly steps: Prisma.InputJsonValue };
+
+export interface RetryHandlerParams {
+  readonly conn: Connection;
+  readonly dataBaseUrl: string;
+  readonly instance: string;
+  readonly queueName?: string;
+  readonly exchangeName?: string;
+  readonly prefetch?: number;
+  readonly log: Logger;
+  readonly retryCount?: number;
+  readonly historyLength?: number;
+  readonly initialRetryDelay?: number;
+  readonly reclaimInterval?: number;
+  readonly prisma?: PrismaClient;
+  readonly handlerConfig?: Partial<RetryHandlerConfig>;
+  readonly sys?: SysAbstraction;
+}
+
+export function randomDelayStrategy(step: number, initial: number, sys: SysAbstraction): number {
+  const prev = initial ** (step - 1);
+  const variance = prev * 2;
+  return prev + sys.Random0ToValue(variance);
+}
+
+export function keyAsString(unk: unknown): string {
+  switch (typeof unk) {
+    case "boolean":
+      return unk ? "true" : "false";
+    case "number":
+      return "" + unk;
+    case "string":
+      return unk;
+    case "object":
+      if (Array.isArray(unk)) {
+        return unk.map((i) => keyAsString(i)).join("|");
+      } else if (unk === null) {
+        return "";
+      } else {
+        const keys = Object.keys(unk).sort();
+        return keys
+          .reduce((acc, key) => {
+            const val = keyAsString((unk as Record<string, unknown>)[key]);
+            acc.push(val);
+            return acc;
+          }, [] as string[])
+          .join("|");
+      }
+    default:
+      throw Error("unknown type:" + typeof unk);
+  }
+}
+
+export class RetryManager {
+  readonly conn: Connection;
+  readonly instance: string;
+  readonly queueName: string;
+  readonly exchangeName: string;
+  readonly dataBaseUrl: string;
+  readonly prefetch: number;
+  readonly historyLength: number;
+  readonly log: Logger;
+  readonly sys: SysAbstraction;
+  readonly prisma: PrismaClient;
+  readonly reclaimInterval: number;
+  readonly handlerConfig: RetryHandlerConfig;
+
+  readonly handlers: Map<string, RetryHandler<unknown>> = new Map();
+
+  _ch?: Channel;
+
+  constructor(param: RetryHandlerParams) {
+    this.conn = param.conn;
+    let quName = param.queueName;
+    let exName = param.exchangeName;
+    if (!quName) {
+      quName = "retry-queue-" + param.instance;
+    }
+    if (!exName) {
+      exName = "retry-exchange-" + param.instance;
+    }
+    this.instance = param.instance;
+    this.queueName = quName;
+    this.exchangeName = exName;
+    this.dataBaseUrl = param.dataBaseUrl;
+    this.prefetch = param.prefetch || 4;
+    this.log = param.log.With().Module("RetryManager").Str("instance", param.instance).Logger();
+    this.historyLength = param.historyLength || 10;
+    this.sys = param.sys || new SystemAbstractionImpl();
+    this.reclaimInterval = param.reclaimInterval || 1000 * 60;
+    const handlerConfig = param.handlerConfig || ({} as Partial<RetryHandlerConfig>);
+    this.handlerConfig = {
+      refreshInterval: handlerConfig.refreshInterval || 7 * 24 * 60 * 60 * 1000,
+      errorRetryInterval: handlerConfig.errorRetryInterval || 24 * 60 * 60 * 1000,
+      restartInterval: handlerConfig.restartInterval || 4 * 60 * 60 * 1000,
+      retryCount: handlerConfig.retryCount || 3,
+      initialRetryDelay: param.initialRetryDelay || 2,
+      delayStrategy: handlerConfig.delayStrategy || ((step, initial) => initial ** step),
+    };
+    this.prisma = param.prisma || new PrismaClient({ datasourceUrl: this.dataBaseUrl });
+  }
+
+  async setQueue() {
+    const ch = await this.conn.createChannel();
+
+    await ch.assertExchange(this.exchangeName, "x-delayed-message", {
+      arguments: { "x-delayed-type": "direct" },
+      durable: true,
+    });
+    await ch.assertQueue(this.queueName, { durable: true });
+    await ch.bindQueue(this.queueName, this.exchangeName, "");
+    return ch;
+  }
+
+  registerHandler<T>(handler: RetryHandler<T>) {
+    this.handlers.set(handler.name, handler);
+  }
+
+  async updateState(state: RetryState) {
+    return this.prisma.$transaction(async (prisma) => {
+      const dbState = await prisma.retryStates.findUnique({
+        where: {
+          handler_key: {
+            key: state.key,
+            handler: state.handler,
+          },
+          txn: state.txn,
+        },
+      });
+      if (dbState) {
+        state = {
+          ...state,
+          steps: [...(dbState.steps as unknown as []), ...state.steps].slice(0, this.historyLength),
+        };
+      }
+      return prisma.retryStates.update({
+        where: {
+          handler_key: {
+            key: state.key,
+            handler: state.handler,
+          },
+          txn: state.txn,
+        },
+        data: {
+          state: state.state,
+          steps: state.steps as unknown as Prisma.InputJsonValue,
+          updated_at: state.updated_at,
+        },
+      });
+    });
+  }
+
+  async ensureRetryState<T>(key: string, msg: RetryMsg<T>): Promise<RetryMsg<T> | undefined> {
+    return await this.prisma.$transaction(async (prisma) => {
+      let rs = await prisma.retryStates.findUnique({
+        where: {
+          handler_key: {
+            key: key,
+            handler: msg.handler,
+          },
+        },
+      });
+      if (!rs) {
+        const now = this.sys.Time().Now();
+        rs = await prisma.retryStates.create({
+          data: {
+            state: "new",
+            handler: msg.handler,
+            key: key,
+            real_key: msg.key as unknown as Prisma.InputJsonValue,
+            txn: this.sys.NextId(),
+            steps: [],
+            updated_at: now,
+            created_at: now,
+          },
+        });
+      }
+      if (msg.txn && rs.txn !== msg.txn) {
+        return undefined;
+      }
+      return {
+        ...msg,
+        txn: rs.txn,
+      };
+    });
+  }
+
+  async msgHandler(log: Logger, ch: Channel, msg: ConsumeMessage) {
+    msg.properties = msg.properties || {
+      headers: {},
+    };
+    const now = this.sys.Time().Now();
+    let payload: RetryMsg<unknown> | undefined = undefined;
+    let key: string | undefined = undefined;
+    try {
+      const msgContent = msg.content.toString();
+      payload = JSON.parse(msgContent) as RetryMsg<unknown>;
+      log = this.log.With().Any("payload", payload).Any("headers", msg.properties.headers).Logger();
+      if (!payload) {
+        log.Error().Msg("payload not exist");
+        ch.ack(msg);
+        return;
+      }
+
+      key = keyAsString(payload.key);
+
+      const handler = this.handlers.get(payload.handler);
+      log = log.With().Str("handler", payload.handler).Logger();
+      if (!handler) {
+        ch.ack(msg);
+        log.Error().Msg("handler not found");
+        return;
+      }
+      const txnPayload = await this.ensureRetryState(key, payload);
+      if (!txnPayload) {
+        ch.ack(msg);
+        log.Error().Msg("txn mismatch");
+        return;
+      }
+      payload = txnPayload;
+      log = log.With().Any("payload", payload).Logger();
+
+      if (
+        msg.properties &&
+        msg.properties.headers &&
+        msg.properties.headers["x-retry-count"] &&
+        msg.properties.headers["x-retry-count"] >= (handler.config.retryCount || this.handlerConfig.retryCount)
+      ) {
+        ch.ack(msg);
+        await this.updateState({
+          state: "error",
+          handler: payload.handler,
+          key: key,
+          txn: payload.txn,
+          steps: [{ stepAt: now, value: { payload, headers: msg.properties.headers }, error: { error: "max retry reached" } }],
+          updated_at: now,
+          created_at: now,
+        });
+        log.Error().Uint64("retryCount", msg.properties.headers["x-retry-count"]).Msg("max retry reached");
+        return;
+      }
+      try {
+        const stat = new Stats({
+          feature: handler.name,
+          sys: this.sys,
+        });
+        const res = await stat.Action("", async () => {
+          return handler.handle(msg, payload!, stat);
+        });
+        if (typeof res !== "object") {
+          ch.ack(msg);
+          await this.updateState({
+            state: "error",
+            handler: payload.handler,
+            key: key,
+            txn: payload.txn,
+            steps: [{ stepAt: now, value: { payload, headers: msg.properties.headers }, error: { error: "invalid result" } }],
+            updated_at: now,
+            created_at: now,
+          });
+          log.Error().Msg("handler result invalid");
+          return;
+        }
+        if (res.error) {
+          ch.ack(msg);
+          await this.updateState({
+            state: "error",
+            handler: payload.handler,
+            key: key,
+            txn: payload.txn,
+            steps: [
+              {
+                stepAt: now,
+                value: { payload, headers: msg.properties.headers, ctx: walk(res.ctx, sanitizeJson) },
+                error: { error: res.error.message },
+              },
+            ],
+            updated_at: now,
+            created_at: now,
+          });
+          log.Error().Err(res.error).Any("ctx", res.ctx).Msg("handler reports error");
+          return;
+        }
+        let state = "done";
+        payload = { ...payload, next: res.next };
+        log = log.With().Any("payload", payload).Logger();
+        if (res.retry) {
+          const retryCount = (msg.properties.headers["x-retry-count"] || 0) + 1;
+          (msg.properties.headers["x-delay"] =
+            1000 * this.handlerConfig.delayStrategy(retryCount, this.handlerConfig.initialRetryDelay, this.sys)),
+            (msg.properties.headers["x-retry-count"] = retryCount);
+          ch.publish(this.exchangeName, "", Buffer.from(JSON.stringify(payload)), msg.properties);
+          state = "retrying";
+        } else if (res.next) {
+          ch.publish(this.exchangeName, "", Buffer.from(JSON.stringify(payload)), msg.properties);
+          state = "next";
+        }
+        await this.updateState({
+          state,
+          handler: payload.handler,
+          key: key,
+          txn: payload.txn,
+          steps: [{ stepAt: now, value: { payload, headers: msg.properties.headers, ctx: res.ctx }, stats: stat.RenderCurrent() }],
+          updated_at: now,
+          created_at: now,
+        });
+        ch.ack(msg);
+        log.Debug().Any("stats", stat.RenderCurrent()).Any("res", res).Msg("handler done");
+      } catch (e) {
+        ch.ack(msg);
+        await this.updateState({
+          state: "error",
+          handler: payload.handler,
+          key: key,
+          txn: payload.txn,
+          steps: [{ stepAt: now, value: { payload, headers: msg.properties.headers }, error: { error: (e as Error).message } }],
+          updated_at: now,
+          created_at: now,
+        });
+        log
+          .Error()
+          .Err(e as Error)
+          .Msg("msg unknown error");
+        return;
+      }
+    } catch (e) {
+      if (payload && key) {
+        await this.updateState({
+          state: "error",
+          handler: payload.handler,
+          key: key,
+          txn: payload.txn,
+          steps: [{ stepAt: now, value: { payload, headers: msg.properties.headers }, error: { error: (e as Error).message } }],
+          updated_at: now,
+          created_at: now,
+        });
+      }
+      ch.ack(msg);
+      log
+        .Error()
+        .Err(e as Error)
+        .Msg("channel unknown error");
+      return;
+    }
+  }
+
+  async reclaimByHandler(log: Logger, prisma: PrismaClient, handle: RetryHandler<unknown>, ch: Channel) {
+    const now = this.sys.Time().Now();
+    const toReclaim = await prisma.retryStates.findMany({
+      where: {
+        AND: [
+          {
+            handler: handle.name,
+          },
+          {
+            OR: [
+              {
+                state: "done",
+                updated_at: {
+                  lt: new Date(now.getTime() - (handle.config.refreshInterval || this.handlerConfig.refreshInterval)),
+                },
+              },
+              {
+                state: "error",
+                updated_at: {
+                  lt: new Date(now.getTime() - (handle.config.errorRetryInterval || this.handlerConfig.errorRetryInterval)),
+                },
+              },
+              {
+                state: {
+                  notIn: ["done", "error"],
+                },
+                updated_at: {
+                  lt: new Date(now.getTime() - (handle.config.restartInterval || this.handlerConfig.restartInterval)),
+                },
+              },
+            ],
+          },
+        ],
+      },
+    });
+    for (const claim of toReclaim) {
+      await prisma.retryStates.update({
+        where: {
+          handler_key: {
+            handler: claim.handler,
+            key: claim.key,
+          },
+        },
+        data: {
+          state: "reclaim",
+          updated_at: now,
+        },
+      });
+      this.retrySend(ch)(handle, claim.real_key, claim.txn);
+      log.Debug().Any("claim", claim).Msg("restarted");
+    }
+  }
+
+  async reclaim(ch: Channel) {
+    const log = this.log.With().Str("action", "reclaim").Logger();
+    log.Info().Msg("start");
+    // eslint-disable-next-line no-constant-condition
+    while (true) {
+      const stat = new Stats("reclaim");
+      let prisma: PrismaClient | undefined = undefined;
+      try {
+        prisma = new PrismaClient({ datasourceUrl: this.dataBaseUrl });
+
+        for (const handle of this.handlers.values()) {
+          await stat.Action(handle.name, async () => {
+            await this.reclaimByHandler(log, prisma!, handle, ch);
+          });
+        }
+        log.Info().Any("stats", stat.RenderCurrent()).Msg("reclaimed");
+      } catch (e) {
+        log
+          .Error()
+          .Any("stats", stat.RenderCurrent())
+          .Err(e as Error)
+          .Msg("reclaimed failed");
+      }
+      prisma && prisma?.$disconnect();
+      await new Promise((resolve) => setTimeout(resolve, this.reclaimInterval));
+    }
+  }
+
+  async consumer(ch: Channel) {
+    try {
+      ch.prefetch(this.prefetch);
+      const log = this.log.With().Str("action", "consumer").Logger();
+      log.Info().Msg("start");
+      await ch.consume(this.queueName, async (msg) => {
+        if (!msg) {
+          return;
+        }
+        this.msgHandler(log, ch, msg);
+      });
+    } catch (e) {
+      this.log
+        .Error()
+        .Err(e as Error)
+        .Msg("consume error");
+    }
+  }
+
+  retrySend<T>(ch?: Channel): RetrySend<T> {
+    return (handler, key, txn) => {
+      ch = ch || this._ch;
+      if (!ch) {
+        throw Error("Need a channel");
+      }
+      ch.publish(
+        this.exchangeName,
+        "",
+        Buffer.from(
+          JSON.stringify({
+            key: key,
+            handler: handler.name,
+            txn: txn,
+          } as RetryMsg<unknown>),
+        ),
+      );
+    };
+  }
+
+  async start() {
+    this._ch = await this.setQueue();
+    return Promise.all([this.consumer(this._ch), this.reclaim(this._ch)]);
+  }
+}
+
+export type RetrySend<T> = (h: RetryHandler<T>, key: T, txn?: string) => void;


### PR DESCRIPTION
remove the ampqlib(queue) and prisma dependency.

To Make this functionality abstract.

There should be a test which implements a Small in memory Q to build tests without an actual(external) queue.
